### PR TITLE
free -> delete in ~ABAudio

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -28,7 +28,7 @@ ILLIXR_AUDIO::ABAudio::~ABAudio(){
         delete outputFile;
     }
     for (unsigned int soundIdx = 0; soundIdx < soundSrcs->size(); ++soundIdx){
-        delete soundSrcs->operator[](soundIdx);
+        delete (*soundSrcs)[soundIdx];
     }
     delete soundSrcs;
     delete decoder;

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -25,15 +25,15 @@ ILLIXR_AUDIO::ABAudio::ABAudio(std::string outputFilePath, ProcessType procTypeI
 
 ILLIXR_AUDIO::ABAudio::~ABAudio(){
     if (processType == ILLIXR_AUDIO::ABAudio::ProcessType::FULL){
-        free(outputFile);
+        delete outputFile;
     }
     for (unsigned int soundIdx = 0; soundIdx < soundSrcs->size(); ++soundIdx){
-        free((*soundSrcs)[soundIdx]);
+        delete soundSrcs->operator[](soundIdx);
     }
-    free(soundSrcs);
-    free(decoder);
-    free(rotator);
-    free(zoomer);
+    delete soundSrcs;
+    delete decoder;
+    delete rotator;
+    delete zoomer;
 }
 
 void ILLIXR_AUDIO::ABAudio::loadSource(){


### PR DESCRIPTION
Objects allocated on heap with `new` should be released with `delete`, not `free`.  This is doubly true for objects with non-default destructors (which will not be called by `free`).

Currently, each instance of ABAudio will leak ~100 KB of memory.